### PR TITLE
Feat: 일정 Drag&Drop 기능 추가

### DIFF
--- a/src/atom/Date.ts
+++ b/src/atom/Date.ts
@@ -17,3 +17,10 @@ export const currMonthDatesState = selector<Date[][]>({
   },
 });
 
+/**
+ * Todo 드래그중 onDragEnter가 실행된 Date를 전역으로 저장
+ */
+export const dragOverDateState = atom<Date | null>({
+  key: 'dragOverDateState',
+  default: null,
+})

--- a/src/atom/Todo.ts
+++ b/src/atom/Todo.ts
@@ -1,6 +1,6 @@
-import { atom, selector } from 'recoil';
-import { dateFormatter } from '../core/date';
-import { categoryMapState } from './Category';
+import { atom, selector } from "recoil";
+import { dateFormatter } from "../core/date";
+import { categoryMapState } from "./Category";
 
 export interface Todo {
   id: string;
@@ -12,12 +12,12 @@ export interface Todo {
 }
 
 export const todoListState = atom<Todo[]>({
-  key: 'todoListState',
+  key: "todoListState",
   default: [],
 });
 
 export const dateMappedTodoListState = selector<Map<string, Todo[]>>({
-  key: 'dateMappedTodoListState',
+  key: "dateMappedTodoListState",
   get: ({ get }) => {
     const todos = get(todoListState);
     const categoryMap = get(categoryMapState);
@@ -40,7 +40,11 @@ export const dateMappedTodoListState = selector<Map<string, Todo[]>>({
 });
 
 export const selectedTodoState = atom<Todo | null>({
-  key: 'selectedTodoState',
+  key: "selectedTodoState",
   default: null,
 });
 
+export const dragTodoState = atom<Todo | null>({
+  key: "dragTodoState",
+  default: null,
+});

--- a/src/components/Calendar/CalendarBody.tsx
+++ b/src/components/Calendar/CalendarBody.tsx
@@ -1,11 +1,12 @@
 /** @jsxImportSource @emotion/react */
-import React, { useEffect, useState } from 'react';
-import { css } from '@emotion/react';
-import CalendarDayCell from './CalendarDayCell';
-import CalendarDateCell from './CalendarDateCell';
-import { dateMappedTodoListState, Todo } from '../../atom/Todo';
-import { useRecoilValue } from 'recoil';
-import { dateFormatter } from '../../core/date';
+import React, { useEffect, useState } from "react";
+import { css } from "@emotion/react";
+import CalendarDayCell from "./CalendarDayCell";
+import CalendarDateCell from "./CalendarDateCell";
+import { dateMappedTodoListState, Todo } from "../../atom/Todo";
+import { useRecoilValue } from "recoil";
+import { dateFormatter } from "../../core/date";
+import Droppable from "../UI/Droppable";
 
 interface IProps {
   days: string[];
@@ -13,77 +14,84 @@ interface IProps {
   todoCreateHandler: (date: Date) => boolean;
 }
 
-const CalendarBody = React.memo(({ days, dates, todoCreateHandler }: IProps) => {
-  const [width, setWidth] = useState<number>(window.innerWidth);
-  const todoDateMap = useRecoilValue<Map<string, Todo[]>>(dateMappedTodoListState);
-  const today = new Date();
+const CalendarBody = React.memo(
+  ({ days, dates, todoCreateHandler }: IProps) => {
+    const [width, setWidth] = useState<number>(window.innerWidth);
+    const todoDateMap = useRecoilValue<Map<string, Todo[]>>(
+      dateMappedTodoListState
+    );
+    const today = new Date();
 
-  useEffect(() => {
-    window.addEventListener('resize', resizeHandler);
+    useEffect(() => {
+      window.addEventListener("resize", resizeHandler);
 
-    return () => {
-      window.removeEventListener('resize', resizeHandler);
+      return () => {
+        window.removeEventListener("resize", resizeHandler);
+      };
+    }, [window.innerWidth]);
+
+    const resizeHandler = () => {
+      setWidth(window.innerWidth);
     };
-  }, [window.innerWidth]);
 
-  const resizeHandler = () => {
-    setWidth(window.innerWidth);
-  };
-
-  return (
-    <div
-      css={css`
-        width: 100%;
-        height: ${width <= 480 ? 'calc(60vh - 40px - 60px)' : 'calc(100vh - 40px - 60px)'};
-      `}
-    >
+    return (
       <div
         css={css`
           width: 100%;
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          height: 32px;
+          height: ${width <= 480
+            ? "calc(60vh - 40px - 60px)"
+            : "calc(100vh - 40px - 60px)"};
         `}
       >
-        {days.map((day, idx) => (
-          <CalendarDayCell key={idx} day={day} />
-        ))}
+        <div
+          css={css`
+            width: 100%;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            height: 32px;
+          `}
+        >
+          {days.map((day, idx) => (
+            <CalendarDayCell key={idx} day={day} />
+          ))}
+        </div>
+        <div
+          css={css`
+            width: 100%;
+            height: calc((100% - 32px) / 6);
+          `}
+        >
+          {dates.map((week, weekIdx) => (
+            <div
+              key={weekIdx}
+              css={css`
+                width: 100%;
+                height: 100%;
+                display: flex;
+              `}
+            >
+              {week.map((date, dateIdx) => (
+                <Droppable key={`${weekIdx}-${dateIdx}`} date={date}>
+                  <CalendarDateCell
+                    key={`${weekIdx}-${dateIdx}`}
+                    date={date}
+                    todos={todoDateMap.get(dateFormatter(date))}
+                    todoCreateHandler={todoCreateHandler}
+                    isToday={
+                      today.getFullYear() === date.getFullYear() &&
+                      today.getMonth() === date.getMonth() &&
+                      date.getDate() === today.getDate()
+                    }
+                  />
+                </Droppable>
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
-      <div
-        css={css`
-          width: 100%;
-          height: calc((100% - 32px) / 6);
-        `}
-      >
-        {dates.map((week, weekIdx) => (
-          <div
-            key={weekIdx}
-            css={css`
-              width: 100%;
-              height: 100%;
-              display: flex;
-            `}
-          >
-            {week.map((date, dateIdx) => (
-              <CalendarDateCell
-                key={`${weekIdx}-${dateIdx}`}
-                date={date}
-                todos={todoDateMap.get(dateFormatter(date))}
-                todoCreateHandler={todoCreateHandler}
-                isToday={
-                  today.getFullYear() === date.getFullYear() &&
-                  today.getMonth() === date.getMonth() &&
-                  date.getDate() === today.getDate()
-                }
-              />
-            ))}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 export default CalendarBody;
-

--- a/src/components/Calendar/CalendarDateCell.tsx
+++ b/src/components/Calendar/CalendarDateCell.tsx
@@ -1,11 +1,12 @@
 /** @jsxImportSource @emotion/react */
-import React, { useEffect } from 'react';
-import { css } from '@emotion/react';
-import { useRecoilValue } from 'recoil';
-import { currDateState } from '../../atom/Date';
-import CalendarTodo from './CalendarTodo';
-import { Todo } from '../../atom/Todo';
-import { datetimeFormatter } from '../../core/date';
+import React, { useEffect } from "react";
+import { css } from "@emotion/react";
+import { useRecoilValue } from "recoil";
+import { currDateState } from "../../atom/Date";
+import CalendarTodo from "./CalendarTodo";
+import { Todo } from "../../atom/Todo";
+import { datetimeFormatter } from "../../core/date";
+import Draggable from "../UI/Draggable";
 
 interface IProps {
   date: Date;
@@ -15,13 +16,15 @@ interface IProps {
 }
 
 const areEqualProps = (prevProps: IProps, nextProps: IProps): boolean => {
-  if (datetimeFormatter(prevProps.date) !== datetimeFormatter(nextProps.date)) return false;
+  if (datetimeFormatter(prevProps.date) !== datetimeFormatter(nextProps.date))
+    return false;
   if (prevProps.todos?.length !== nextProps.todos?.length) return false;
 
   if (prevProps.todos && nextProps.todos) {
     for (let i = 0; i < prevProps.todos.length; i++) {
       if (prevProps.todos[i].title !== nextProps.todos[i].title) return false;
-      if (prevProps.todos[i].category !== nextProps.todos[i].category) return false;
+      if (prevProps.todos[i].category !== nextProps.todos[i].category)
+        return false;
       if (prevProps.todos[i].color !== nextProps.todos[i].color) return false;
       if (prevProps.todos[i].desc !== nextProps.todos[i].desc) return false;
     }
@@ -30,76 +33,85 @@ const areEqualProps = (prevProps: IProps, nextProps: IProps): boolean => {
   return true;
 };
 
-const CalendarDateCell = React.memo(({ date, todos, todoCreateHandler, isToday }: IProps) => {
-  const currDate = useRecoilValue<Date>(currDateState);
-  const isThisMonth = currDate.getMonth() === date.getMonth();
+const CalendarDateCell = React.memo(
+  ({ date, todos, todoCreateHandler, isToday }: IProps) => {
+    const currDate = useRecoilValue<Date>(currDateState);
+    const isThisMonth = currDate.getMonth() === date.getMonth();
 
-  return (
-    <div
-      css={css`
-        flex: 1;
-        height: 101%;
-        border: 1px solid #aaa;
-        margin-top: -1px;
-        margin-right: -1px;
-        overflow: hidden;
-
-        &:hover {
-          cursor: pointer;
-        }
-      `}
-      onDoubleClick={() => todoCreateHandler(date)}
-    >
+    return (
       <div
         css={css`
-          width: 100%;
+          flex: 1;
+          height: 101%;
+          border: 1px solid #aaa;
+          margin-top: -1px;
+          margin-right: -1px;
+          overflow: hidden;
+
+          &:hover {
+            cursor: pointer;
+          }
         `}
+        onDoubleClick={() => todoCreateHandler(date)}
       >
-        <p
-          css={css`
-            position: relative;
-            margin: 0;
-            padding: 4px;
-            display: flex;
-            justify-content: flex-end;
-            align-items: center;
-            color: ${isThisMonth ? '#000' : '#aaa'};
-            -webkit-touch-callout: none; /* iOS Safari */
-            -webkit-user-select: none; /* Safari */
-            -ms-user-select: none; /* 인터넷익스플로러 */
-            user-select: none;
-          `}
-        >
-          <span
-            css={css`
-              display: block;
-              position: relative;
-              top: -1px;
-              width: ${isToday ? '24px' : 'auto'};
-              height: 24px;
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              border-radius: 1rem;
-              background: ${isToday ? '#f35d54' : ''};
-            `}
-          >
-            {date.getDate()}
-          </span>
-          일
-        </p>
         <div
           css={css`
             width: 100%;
-            padding: 0 1px;
           `}
         >
-          {todos && todos.map((todo) => <CalendarTodo key={todo.id} todo={todo} />)}
+          <p
+            css={css`
+              position: relative;
+              margin: 0;
+              padding: 4px;
+              display: flex;
+              justify-content: flex-end;
+              align-items: center;
+              color: ${isThisMonth ? "#000" : "#aaa"};
+              -webkit-touch-callout: none; /* iOS Safari */
+              -webkit-user-select: none; /* Safari */
+              -ms-user-select: none; /* 인터넷익스플로러 */
+              user-select: none;
+            `}
+          >
+            <span
+              css={css`
+                display: block;
+                position: relative;
+                top: -1px;
+                width: ${isToday ? "24px" : "auto"};
+                height: 24px;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                border-radius: 1rem;
+                background: ${isToday ? "#f35d54" : ""};
+              `}
+            >
+              {date.getDate()}
+            </span>
+            일
+          </p>
+          <div
+            css={css`
+              width: 100%;
+              padding: 0 1px;
+            `}
+          >
+            {todos &&
+              todos.map((todo) => {
+                return (
+                  <Draggable key={todo.id} todo={todo}>
+                    <CalendarTodo key={todo.id} todo={todo} />
+                  </Draggable>
+                );
+              })}
+          </div>
         </div>
       </div>
-    </div>
-  );
-}, areEqualProps);
+    );
+  },
+  areEqualProps
+);
 
 export default CalendarDateCell;
-

--- a/src/components/Calendar/CalendarDateCell.tsx
+++ b/src/components/Calendar/CalendarDateCell.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource @emotion/react */
-import React, { useEffect } from "react";
+import React, { useMemo } from "react";
 import { css } from "@emotion/react";
 import { useRecoilValue } from "recoil";
-import { currDateState } from "../../atom/Date";
+import { currDateState, dragOverDateState } from "../../atom/Date";
 import CalendarTodo from "./CalendarTodo";
-import { Todo } from "../../atom/Todo";
+import { dragTodoState, Todo } from "../../atom/Todo";
 import { datetimeFormatter } from "../../core/date";
 import Draggable from "../UI/Draggable";
 
@@ -33,24 +33,36 @@ const areEqualProps = (prevProps: IProps, nextProps: IProps): boolean => {
   return true;
 };
 
-const CalendarDateCell = React.memo(
-  ({ date, todos, todoCreateHandler, isToday }: IProps) => {
+const CalendarDateCell = ({date, todos, todoCreateHandler, isToday}: IProps) => {
     const currDate = useRecoilValue<Date>(currDateState);
     const isThisMonth = currDate.getMonth() === date.getMonth();
+    const dragOverDate = useRecoilValue<Date | null>(dragOverDateState); // drag중 hover되는 DateCell의 Date 객체 저장
+    const dragTodo = useRecoilValue<Todo | null>(dragTodoState); // drag중인 Todo 객체 저장
+
+    // drag중 drop전에 drop된 UI를 미리 표시하는 UI
+    const skeletonTodo = useMemo(() => {
+      if (dragOverDate && dragOverDate.getMonth() === date.getMonth() && dragOverDate.getDate() === date.getDate() ? true : false) {
+        return (<CalendarTodo todo={dragTodo as Todo} />);
+      } else return;
+    }, [dragOverDate]);
 
     return (
+      // 기존에 CalendarDateCell에 있던 style을 Droppable에 적용함
       <div
         css={css`
-          flex: 1;
-          height: 101%;
-          border: 1px solid #aaa;
-          margin-top: -1px;
-          margin-right: -1px;
-          overflow: hidden;
+          box-sizing:border-box;
+          width: 100%;
+          height: 100%;
+          // flex: 1;
+          // height: 101%;
+          // border: 1px solid #aaa;
+          // margin-top: -1px;
+          // margin-right: -1px;
+          // overflow: hidden;
 
-          &:hover {
-            cursor: pointer;
-          }
+          // &:hover {
+          //   cursor: pointer;
+          // }
         `}
         onDoubleClick={() => todoCreateHandler(date)}
       >
@@ -106,12 +118,11 @@ const CalendarDateCell = React.memo(
                   </Draggable>
                 );
               })}
+              {skeletonTodo}
           </div>
         </div>
       </div>
     );
-  },
-  areEqualProps
-);
+  }
 
-export default CalendarDateCell;
+export default React.memo(CalendarDateCell, areEqualProps);

--- a/src/components/Calendar/CalendarTodo.tsx
+++ b/src/components/Calendar/CalendarTodo.tsx
@@ -8,7 +8,8 @@ interface IProps {
   todo: Todo;
 }
 
-const CalendarTodo = ({ todo }: IProps) => {
+// forwardRef를 사용하여 ref를 전달함
+const CalendarTodo = React.forwardRef(({ todo }: IProps, ref: React.ForwardedRef<HTMLDivElement> | undefined) => {
   const setSelected = useSetRecoilState(selectedTodoState);
 
   const selectTodoHandler = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -36,6 +37,7 @@ const CalendarTodo = ({ todo }: IProps) => {
       key={todo.id}
       onClick={selectTodoHandler}
       onDoubleClick={selectTodoHandler}
+      ref={ref}
     >
       <p
         css={css`
@@ -48,7 +50,7 @@ const CalendarTodo = ({ todo }: IProps) => {
       </p>
     </div>
   );
-};
+});
 
 export default CalendarTodo;
 

--- a/src/components/UI/Draggable.tsx
+++ b/src/components/UI/Draggable.tsx
@@ -1,23 +1,30 @@
 /** @jsxImportSource @emotion/react */
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { css } from "@emotion/react";
-import { useSetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 import { dragTodoState, Todo } from "../../atom/Todo";
 
 interface IProps {
-  children: React.ReactNode;
+  children: React.ReactElement;
   todo: Todo;
 }
 
 const Draggable = ({ children, todo }: IProps) => {
-  const setDragTodo = useSetRecoilState(dragTodoState);
+  const childRef = useRef<HTMLDivElement | null>(null);
+  const [dragTodo, setDragTodo] = useRecoilState(dragTodoState);
 
-  const onDragStartHandler = (
-    e: React.DragEvent<HTMLDivElement>,
-    todo: Todo
-  ) => {
+  const onDragStartHandler = (e: React.DragEvent<HTMLDivElement>, todo: Todo) => {
     setDragTodo(todo);
-  };
+    if (childRef.current) {
+      childRef.current.style.opacity = "0.5";
+    }
+  }
+
+  useEffect(() => {
+    if (dragTodo === null && childRef.current) {
+      childRef.current.style.opacity = "1";
+    }
+  }, [dragTodo]);
 
   return (
     <div
@@ -25,7 +32,9 @@ const Draggable = ({ children, todo }: IProps) => {
       onDragStart={(e) => onDragStartHandler(e, todo)}
       draggable={true}
     >
-      {children}
+      {React.Children.map(children, (child: React.ReactElement) => {
+        return React.cloneElement(child, { ref: childRef });
+      })}
     </div>
   );
 };

--- a/src/components/UI/Draggable.tsx
+++ b/src/components/UI/Draggable.tsx
@@ -1,0 +1,33 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import { css } from "@emotion/react";
+import { useSetRecoilState } from "recoil";
+import { dragTodoState, Todo } from "../../atom/Todo";
+
+interface IProps {
+  children: React.ReactNode;
+  todo: Todo;
+}
+
+const Draggable = ({ children, todo }: IProps) => {
+  const setDragTodo = useSetRecoilState(dragTodoState);
+
+  const onDragStartHandler = (
+    e: React.DragEvent<HTMLDivElement>,
+    todo: Todo
+  ) => {
+    setDragTodo(todo);
+  };
+
+  return (
+    <div
+      css={css``}
+      onDragStart={(e) => onDragStartHandler(e, todo)}
+      draggable={true}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Draggable;

--- a/src/components/UI/Droppable.tsx
+++ b/src/components/UI/Droppable.tsx
@@ -1,27 +1,45 @@
 /** @jsxImportSource @emotion/react */
-import React from "react";
+import React, { useCallback } from "react";
 import { css } from "@emotion/react";
 import { useRecoilState } from "recoil";
 import { dragTodoState, Todo } from "../../atom/Todo";
 import useCalendar from "../../hooks/useCalendar";
+import { dragOverDateState } from "../../atom/Date";
 
 interface IProps {
   date: Date;
-  children: React.ReactNode;
+  children: React.ReactElement;
 }
 
-const Droppable = ({ date, children }: IProps) => {
+const Droppable = ({ date, children}: IProps) => {
   const { updateTodo } = useCalendar();
   const [dragTodoValue, setDragTodo] = useRecoilState(dragTodoState);
+  const [dragOverDate, setDragOverDate] = useRecoilState(dragOverDateState);
+
+  const onDragEnterHandler = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (dragOverDate === date) return;
+    setDragOverDate(date);
+  }, [date]);
 
   const onDragOverHandler = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
   };
 
-  const onDropHandler = (e: React.DragEvent<HTMLDivElement>, date: Date) => {
-    updateTodo({ ...dragTodoValue, date: date } as Todo);
-    setDragTodo(null);
-  };
+  const onDropHandler = useCallback(
+    (e: React.DragEvent<HTMLDivElement>, date: Date) => {
+      e.preventDefault();
+      const newDate = new Date(dragTodoValue?.date as Date);
+      newDate.setFullYear(date.getFullYear());
+      newDate.setMonth(date.getMonth());
+      newDate.setDate(date.getDate());
+      updateTodo({ ...dragTodoValue, date: newDate } as Todo);
+      setDragTodo(null);
+      setDragOverDate(null);
+    },
+    [dragTodoValue]
+  );
 
   return (
     <div
@@ -37,6 +55,7 @@ const Droppable = ({ date, children }: IProps) => {
           cursor: pointer;
         }
       `}
+      onDragEnter={onDragEnterHandler}
       onDragOver={onDragOverHandler}
       onDrop={(e) => onDropHandler(e, date)}
     >

--- a/src/components/UI/Droppable.tsx
+++ b/src/components/UI/Droppable.tsx
@@ -1,0 +1,48 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import { css } from "@emotion/react";
+import { useRecoilState } from "recoil";
+import { dragTodoState, Todo } from "../../atom/Todo";
+import useCalendar from "../../hooks/useCalendar";
+
+interface IProps {
+  date: Date;
+  children: React.ReactNode;
+}
+
+const Droppable = ({ date, children }: IProps) => {
+  const { updateTodo } = useCalendar();
+  const [dragTodoValue, setDragTodo] = useRecoilState(dragTodoState);
+
+  const onDragOverHandler = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const onDropHandler = (e: React.DragEvent<HTMLDivElement>, date: Date) => {
+    updateTodo({ ...dragTodoValue, date: date } as Todo);
+    setDragTodo(null);
+  };
+
+  return (
+    <div
+      css={css`
+        flex: 1;
+        height: 101%;
+        border: 1px solid #aaa;
+        margin-top: -1px;
+        margin-right: -1px;
+        overflow: hidden;
+
+        &:hover {
+          cursor: pointer;
+        }
+      `}
+      onDragOver={onDragOverHandler}
+      onDrop={(e) => onDropHandler(e, date)}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Droppable;


### PR DESCRIPTION
[[Feat]: Draggble & Droppable 공용 컴포넌트 추가 #20](https://github.com/PakaOxO/every-calin/issues/20)
### Description
- 일정 Drag&Drop 기능 개발
  - 일정을 Drag&Drop으로 다른날짜로 이동시킬 수 있습니다.
  - 옮겨진 일정(`todo`)의 `date`필드는 변경 이후 날짜로 수정됩니다.
  - Drag 중 현재 마우스 위치에 따라 Droppable 요소에 Drop 결과를 미리보기로 표시합니다.
- Draggable, Droppable 컴포넌트 추가
- CalendarDateCell 컴포넌트 내부 skeletonTodo 코드 추가
- 전역으로 dragTodoState, dragOverDateState 추가

### etc
- 임시적으로 CalendarDateCell의 style을 Droppable의 style로 이동 및 적용하였습니다.
- 전역 저장된 dragOverDateState를 모든 CalendarDateCell에 공유하고 있으므로 재렌더링 이슈가 있습니다.
- Draggable 컴포넌트에서 children으로 childRef를 전달하기 위해 사용된 React.cloneElement()가 불안정하다는 React 공식문서의 내용이 있습니다.
- Draggable과 Droppable 컴포넌트가 외부 컴포넌트와 완벽하게 독립되지 않았습니다.
- Draggable과 Droppable 내부의 dropEventHandler를 custom hook으로 만들 필요가 있어보입니다.
