### PR TITLE
[Feat]/#21: popup 공통 컴포넌트 추가 및 일정 정보 팝업으로 변경

### DIFF
--- a/src/atom/Todo.ts
+++ b/src/atom/Todo.ts
@@ -44,3 +44,8 @@ export const selectedTodoState = atom<Todo | null>({
   default: null,
 });
 
+export const selectedTodoRefState = atom<HTMLDivElement | null>({
+  key: 'selectedTodoRefState',
+  default: null,
+});
+

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -9,8 +9,8 @@ import { currDateState } from '../../atom/Date';
 import CalendarTopMenu from './CalendarTopMenu';
 import CalendarSettingMenu from './CalendarSettingMenu';
 import { settingMenuState, todoMenuState } from '../../atom/Menu';
-import CalendarTodoMenu from './CalendarTodoMenu';
-import { selectedTodoState, Todo } from '../../atom/Todo';
+import { selectedTodoRefState, selectedTodoState, Todo } from '../../atom/Todo';
+import TodoPopup from './TodoPopup';
 
 const Calendar = () => {
   const currDate = useRecoilValue<Date>(currDateState);
@@ -18,8 +18,9 @@ const Calendar = () => {
     useCalendar();
   const dates: Date[][] = useMemo(() => getThisMonth(currDate, 6), [currDate]);
   const leftMenuIsOpen = useRecoilValue<boolean>(settingMenuState);
-  const rightMenuIsOpen = useRecoilValue<boolean>(todoMenuState);
+  const popupIsOpen = useRecoilValue<boolean>(todoMenuState);
   const [selectedTodo, setSelectedTodo] = useRecoilState<Todo | null>(selectedTodoState);
+  const [todoRef, setTodoRef] = useRecoilState(selectedTodoRefState);
 
   useEffect(() => {
     getCategoryList();
@@ -28,6 +29,7 @@ const Calendar = () => {
   const resetSelectedTodoHandler = () => {
     if (!!!selectedTodo) return;
     setSelectedTodo(null);
+    setTodoRef(null);
   };
 
   return (
@@ -65,17 +67,7 @@ const Calendar = () => {
         <CalendarTopMenu />
         <CalendarHeader date={currDate} />
         <CalendarBody days={days} dates={dates} todoCreateHandler={createTodo} />
-      </section>
-      <section
-        css={css`
-          width: ${rightMenuIsOpen ? '240px' : '0px'};
-          overflow: hidden;
-          transition: width 0.3s ease;
-          border-left: 1px solid #aaa;
-          margin-right: -1px;
-        `}
-      >
-        <CalendarTodoMenu todoUpdateHandler={updateTodo} />
+        <TodoPopup open={popupIsOpen} anchor={todoRef} todoUpdateHandler={updateTodo} />
       </section>
     </div>
   );

--- a/src/components/Calendar/CalendarTodo.tsx
+++ b/src/components/Calendar/CalendarTodo.tsx
@@ -1,20 +1,30 @@
 /** @jsxImportSource @emotion/react */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { css } from '@emotion/react';
-import { selectedTodoState, Todo } from '../../atom/Todo';
-import { useSetRecoilState } from 'recoil';
+import { selectedTodoRefState, selectedTodoState, Todo } from '../../atom/Todo';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 interface IProps {
   todo: Todo;
 }
 
 const CalendarTodo = ({ todo }: IProps) => {
-  const setSelected = useSetRecoilState(selectedTodoState);
+  const [selected, setSelected] = useRecoilState(selectedTodoState);
+  const setSelectedTodoRef = useSetRecoilState(selectedTodoRefState);
+  const todoRef = useRef<HTMLDivElement | null>(null);
 
   const selectTodoHandler = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
     setSelected(todo);
   };
+
+  useEffect(() => {
+    if (selected && selected.id === todo.id) {
+      if (todoRef.current !== null) {
+        setSelectedTodoRef(todoRef.current);
+      }
+    }
+  }, [selected]);
 
   return (
     <div
@@ -36,6 +46,7 @@ const CalendarTodo = ({ todo }: IProps) => {
       key={todo.id}
       onClick={selectTodoHandler}
       onDoubleClick={selectTodoHandler}
+      ref={todoRef}
     >
       <p
         css={css`

--- a/src/components/Calendar/CalendarTodoMenu.tsx
+++ b/src/components/Calendar/CalendarTodoMenu.tsx
@@ -37,8 +37,12 @@ const CalendarTodoMenu = ({ todoUpdateHandler }: IProps) => {
   return (
     <div
       css={css`
-        width: 240px;
+        width: 280px;
+        height: 300px;
         padding: 8px;
+        background: rgba(255, 255, 255, 0.9);
+        border: 1px solid white;
+        box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
       `}
       onClick={(e: React.MouseEvent<HTMLDivElement>) => {
         e.stopPropagation();

--- a/src/components/Calendar/TodoPopup.tsx
+++ b/src/components/Calendar/TodoPopup.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Popup from '../UI/Popup';
+import CalendarTodoMenu from './CalendarTodoMenu';
+import { Todo } from '../../atom/Todo';
+
+type TVertical = 'top' | 'mid' | 'bottom';
+type THorizontal = 'left' | 'center' | 'right';
+
+interface IProps {
+  open: boolean;
+  anchor: HTMLDivElement | null;
+  todoUpdateHandler: (todo: Todo) => void;
+}
+
+const TodoPopup = ({ open, anchor, todoUpdateHandler }: IProps) => {
+  const [anchorTop, anchorLeft] = [anchor?.offsetTop || 0, anchor?.offsetLeft || 0];
+  const [windowHeight, windowWidth] = [window.innerHeight, window.innerWidth];
+
+  const aVertical = anchorTop < windowHeight / 2 ? 'top' : 'bottom';
+  const aHorizontal = anchorLeft < windowWidth / 2 ? 'right' : 'left';
+
+  const tVertical = anchorTop < windowHeight / 2 ? 'top' : 'bottom';
+  const tHorizontal = anchorLeft < windowWidth / 2 ? 'left' : 'right';
+
+  if (anchor === null) return null;
+
+  return (
+    <Popup
+      open={open}
+      width={280}
+      height={300}
+      anchorEl={anchor}
+      anchorOrigin={{ vertical: aVertical, horizontal: aHorizontal }}
+      transformOrigin={{ vertical: tVertical, horizontal: tHorizontal }}
+    >
+      <CalendarTodoMenu todoUpdateHandler={todoUpdateHandler} />
+    </Popup>
+  );
+};
+
+export default TodoPopup;
+

--- a/src/components/UI/Popup.tsx
+++ b/src/components/UI/Popup.tsx
@@ -1,0 +1,73 @@
+/** @jsxImportSource @emotion/react */
+import React, { useRef } from 'react';
+import { css } from '@emotion/react';
+
+interface IOrigin {
+  vertical: 'top' | 'mid' | 'bottom';
+  horizontal: 'left' | 'center' | 'right';
+}
+
+interface IProps {
+  open: boolean;
+  width: number;
+  height: number;
+  anchorEl: HTMLDivElement;
+  anchorOrigin: IOrigin;
+  transformOrigin: IOrigin;
+  children: React.ReactNode;
+}
+
+const Popup = ({ open, width, height, anchorEl, anchorOrigin, transformOrigin, children }: IProps) => {
+  const popupRef = useRef<HTMLDivElement | null>(null);
+  const [offsetTop, offsetLeft] = [anchorEl?.offsetTop || 0, anchorEl?.offsetLeft || 0];
+  const [anchorWidth, anchorHeight] = [anchorEl?.offsetWidth || 0, anchorEl?.offsetHeight || 0];
+
+  const originTop =
+    offsetTop +
+    (anchorOrigin.vertical === 'top' ? 0 : anchorOrigin.vertical === 'mid' ? anchorHeight / 2 : anchorHeight);
+  const originLeft =
+    offsetLeft +
+    (anchorOrigin.horizontal === 'left' ? 0 : anchorOrigin.horizontal === 'center' ? anchorWidth / 2 : anchorWidth);
+
+  const transformTop = -(transformOrigin.vertical === 'top'
+    ? 0
+    : transformOrigin.vertical === 'mid'
+    ? height / 2
+    : height);
+  const transformLeft = -(transformOrigin.horizontal === 'left'
+    ? 0
+    : transformOrigin.horizontal === 'center'
+    ? width / 2
+    : width);
+
+  return (
+    <dialog
+      css={css`
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        border: none;
+        background: transparent;
+        z-index: 10;
+      `}
+      open={open}
+    >
+      <div
+        css={css`
+          position: absolute;
+          top: ${originTop + transformTop}px;
+          left: ${originLeft + transformLeft}px;
+          box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+        `}
+        ref={popupRef}
+      >
+        {children}
+      </div>
+    </dialog>
+  );
+};
+
+export default Popup;
+


### PR DESCRIPTION
### Description
- 우측 슬라이드 메뉴였던 일정 정보 메뉴를 팝업으로 변경했습니다.
- 팝업은 `Popup` 공통 컴포넌트를 작성한 뒤 이를 활용하는 방식으로 구성했습니다.
- `Popup` 컴포넌트가 받는 `props`는 아래와 같습니다.

```ts
{
  open: boolean; // popup open 여부
  width: number; // popup 너비
  height: number; // popup 높이
  anchorEl: HTMLDivElement; // popup이 열릴 위치 기준을 잡기 위한 요소
  anchorOrigin: IOrigin; // anchor 기준 어느 모서리에서 열릴지 결정
  transformOrigin: IOrigin; // anchor의 모서리와 맞닿을 popup 모서리의 위치
  children: React.ReactNode; // popup 안에 표시할 자식 요소
}
```

### etc.
- `props` 요소 중 `origin`은 객체 타입으로 `IOrigin`으로 정의했습니다.
- `IOrigin`의 구조는 다음과 같습니다.

```ts
{
  vertical: 'top' | 'mid' | 'bottom';
  horizontal: 'left' | 'center' | 'right';
}
``